### PR TITLE
battery indicator in item menu

### DIFF
--- a/hud.c
+++ b/hud.c
@@ -1255,10 +1255,10 @@ void Hud_DrawSelectedYButtonItem() {  // 8deb3a
   }
   Hud_IntToDecimal(g_battery.level, d); // TODO: use global battery value
   if(d[1] > 0x90)
-    dst_box[HUDXY(27, 5)] = base | d[1];
+    dst_box[HUDXY(27, 4)] = base | d[1];
   if(d[2] > 0x90 || d[1] > 0x90)
-    dst_box[HUDXY(28, 5)] = base | d[2];
-  dst_box[HUDXY(29, 5)] = base | d[3];
+    dst_box[HUDXY(28, 4)] = base | d[2];
+  dst_box[HUDXY(29, 4)] = base | d[3];
 #endif
 }
 

--- a/hud.c
+++ b/hud.c
@@ -4,19 +4,13 @@
 #include "variables.h"
 #include "messaging.h"
 
-<<<<<<< Updated upstream
-=======
 #define MENU_ANIM_STEP 16  // Default: 8; absolute max value 232
 
-#ifndef BATTERY_INDICATOR
-#define BATTERY_INDICATOR 0
-#endif
 
 #if BATTERY_INDICATOR
-uint8_t g_battery_level = 0;
+battery_t g_battery = {.level=0, .is_charging=false};
 #endif
 
->>>>>>> Stashed changes
 enum {
   kNewStyleInventory = 0,
   kHudItemCount = kNewStyleInventory ? 24 : 20,
@@ -1254,13 +1248,17 @@ void Hud_DrawSelectedYButtonItem() {  // 8deb3a
   Hud_DrawNxN(dst_box + HUDXY(22, 8), src_p, 8, 2);
 
 #if BATTERY_INDICATOR
+  uint16_t base = 0x2400;
   uint8_t d[4];
-  Hud_IntToDecimal(g_battery_level, d); // TODO: use global battery value
+  if(g_battery.is_charging){
+    base = 0x3400;
+  }
+  Hud_IntToDecimal(g_battery.level, d); // TODO: use global battery value
   if(d[1] > 0x90)
-    dst_box[HUDXY(27, 5)] = 0x2400 | d[1];
+    dst_box[HUDXY(27, 5)] = base | d[1];
   if(d[2] > 0x90 || d[1] > 0x90)
-    dst_box[HUDXY(28, 5)] = 0x2400 | d[2];
-  dst_box[HUDXY(29, 5)] = 0x2400 | d[3];
+    dst_box[HUDXY(28, 5)] = base | d[2];
+  dst_box[HUDXY(29, 5)] = base | d[3];
 #endif
 }
 

--- a/hud.c
+++ b/hud.c
@@ -4,6 +4,19 @@
 #include "variables.h"
 #include "messaging.h"
 
+<<<<<<< Updated upstream
+=======
+#define MENU_ANIM_STEP 16  // Default: 8; absolute max value 232
+
+#ifndef BATTERY_INDICATOR
+#define BATTERY_INDICATOR 0
+#endif
+
+#if BATTERY_INDICATOR
+uint8_t g_battery_level = 0;
+#endif
+
+>>>>>>> Stashed changes
 enum {
   kNewStyleInventory = 0,
   kHudItemCount = kNewStyleInventory ? 24 : 20,
@@ -18,6 +31,7 @@ static bool Hud_DoWeHaveThisItem(uint8 item);
 static void Hud_EquipPrevItem(uint8 *item);
 static void Hud_EquipNextItem(uint8 *item);
 static int Hud_GetItemPosition(int item);
+static void Hud_IntToDecimal(unsigned int number, uint8 *out);
 static void Hud_ReorderItem(int direction);
 static void Hud_Update_Magic();
 static void Hud_Update_Inventory();
@@ -1003,6 +1017,7 @@ void Hud_DrawYButtonItems() {  // 8de3d9
     dst[HUDXY(2, 6)] = kEquipmentLetterTiles[btn_index][0];
     dst[HUDXY(2, 7)] = kEquipmentLetterTiles[btn_index][1]; 
   }
+  // ITEM text
   dst[HUDXY(x + 2, 5)] = 0x246E;
   dst[HUDXY(x + 3, 5)] = 0x246F;
 
@@ -1237,6 +1252,16 @@ void Hud_DrawSelectedYButtonItem() {  // 8deb3a
     src_p = &kHudItemText[(item - 1) * 16];
   }
   Hud_DrawNxN(dst_box + HUDXY(22, 8), src_p, 8, 2);
+
+#if BATTERY_INDICATOR
+  uint8_t d[4];
+  Hud_IntToDecimal(g_battery_level, d); // TODO: use global battery value
+  if(d[1] > 0x90)
+    dst_box[HUDXY(27, 5)] = 0x2400 | d[1];
+  if(d[2] > 0x90 || d[1] > 0x90)
+    dst_box[HUDXY(28, 5)] = 0x2400 | d[2];
+  dst_box[HUDXY(29, 5)] = 0x2400 | d[3];
+#endif
 }
 
 void Hud_DrawEquipmentBox() {  // 8ded29

--- a/hud.c
+++ b/hud.c
@@ -1253,11 +1253,19 @@ void Hud_DrawSelectedYButtonItem() {  // 8deb3a
   if(g_battery.is_charging){
     base = 0x3400;
   }
+
   Hud_IntToDecimal(g_battery.level, d); // TODO: use global battery value
+                                        //
   if(d[1] > 0x90)
     dst_box[HUDXY(27, 4)] = base | d[1];
+  else
+    dst_box[HUDXY(27, 4)] = 0x207f; // Erase
+
   if(d[2] > 0x90 || d[1] > 0x90)
     dst_box[HUDXY(28, 4)] = base | d[2];
+  else
+    dst_box[HUDXY(28, 4)] = 0x207f; // Erase
+
   dst_box[HUDXY(29, 4)] = base | d[3];
 #endif
 }

--- a/hud.h
+++ b/hud.h
@@ -1,6 +1,19 @@
 #pragma once
 #include "types.h"
 
+#ifndef BATTERY_INDICATOR
+#define BATTERY_INDICATOR 0
+#endif
+
+#if BATTERY_INDICATOR
+typedef struct {
+  uint8_t level;
+  bool is_charging;
+} battery_t;
+
+extern battery_t g_battery;
+#endif
+
 enum kHudItems {
 
   kHudItem_Bombs = 4,


### PR DESCRIPTION
Displays up to 3 digits of the global `uint8_t g_battery_level` on the top right of the item menu if macro `BATTER_INDICATOR=1`. Actual battery measuring logic will go into game-and-watch-zelda3.

![image](https://user-images.githubusercontent.com/14318576/236632883-bf6c260c-3fbd-4471-bf57-bf571352f2f2.png)
